### PR TITLE
Append uaccess and udev-acl tags to udev rule.

### DIFF
--- a/debian/libvitamtp5.udev
+++ b/debian/libvitamtp5.udev
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ATTR{product}=="*PS Vita* Type B", GROUP="vitamtp", MODE="0660"
+SUBSYSTEM=="usb", ATTR{product}=="*PS Vita* Type B", GROUP="vitamtp", MODE="0660", TAG+="uaccess", TAG+="udev-acl"


### PR DESCRIPTION
uaccess rule sets up acl's for the usb device on logind (systemd)
systems.

udev-acl rule does the same for consolekit systems.

This removes the need of adding user to vitamtp group for most users.
It's still useful over ssh or somewhere where login manager doesn't
consider the session to be interactive.